### PR TITLE
Add SGC Trainee Recruitment Drive 2025 event

### DIFF
--- a/src/data/events_data.tsx
+++ b/src/data/events_data.tsx
@@ -7,6 +7,13 @@ export const events = [
         image: "https://res.cloudinary.com/drgwlnf67/image/upload/v1775480924/IMG_20260326_133551_kjhukj.jpg",
         link: "https://www.linkedin.com/posts/studentguidancecell-cahcet_studentsguidancecell-sgc-hiring-activity-7441861224826515456-Zlfj?utm_source=share&utm_medium=member_desktop&rcm=ACoAAFC3TJMBgddb2XkoAqrMwgavyuA1j0w-W8A",
       },
+    {
+        name: "SGC Trainee Recruitment Drive 2025",
+        description: "We successfully conducted the Student Guidance Cell (SGC) Recruitment Drive, offering trainee opportunities to enthusiastic students eager to be part of our team. Through a structured selection process, we identified passionate and capable individuals. We are proud to have executed the event smoothly, marking another step towards strengthening our SGC community.",
+        date: "2025-09-11",
+        image: "https://res.cloudinary.com/db45ygusv/image/upload/v1775586571/WhatsApp_Image_2026-04-07_at_9.53.31_PM_kurfbm.jpg",
+        link: "https://www.linkedin.com/posts/studentguidancecell-cahcet_studentsguidancecell-sgc-hiring-activity-7441861224826515456-Zlfj?utm_source=share&utm_medium=member_desktop&rcm=ACoAAFC3TJMBgddb2XkoAqrMwgavyuA1j0w-W8A",
+      },
       {
         name: "Critical Thinking Workshop 2025",
         description: "We at the Student Guidance Cell (SGC), C. Abdul Hakeem College of Engineering & Technology, organized the 'Critical Thinking' workshop for first-year students. The session featured engaging puzzles, group activities, and the game 'Think Out of the Box,' helping students develop problem-solving, creative thinking, and decision-making skills. Guest speakers Mr. Tejesh Pichandi (Founder, HangouTech Pvt. Ltd.) and Mr. Mohammed Zabeer. Z (Public Speaker & Ph.D. Aspirant) shared inspiring insights on innovation, goal-setting, and a growth mindset.",


### PR DESCRIPTION
Added a new event entry for the SGC Trainee Recruitment Drive 2025, including details such as name, description, date, image, and link.